### PR TITLE
Change token file permissions to 0600

### DIFF
--- a/Sources/trailer/Core/Config.swift
+++ b/Sources/trailer/Core/Config.swift
@@ -91,7 +91,9 @@ struct Config {
 			return ""
 		}
 		set {
-			try! newValue.data(using: .utf8)?.write(to: saveLocation.appendingPathComponent("token"))
+			let tokenFileURL = saveLocation.appendingPathComponent("token")
+			try! newValue.data(using: .utf8)?.write(to: tokenFileURL)
+			try! FileManager.default.setAttributes([.posixPermissions: NSNumber(0o600)], ofItemAtPath: tokenFileURL.path)
 		}
 	}
 


### PR DESCRIPTION
Given that a GitHub access token is similar to a password it should be kept from prying eyes, thus changing the token file permissions to user read-write only (`chmod 0600`) and not allowing read or other permissions to the user's group or others seems like a step in the right direction.